### PR TITLE
edited at line no. 99

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
           <a href="https://www.linkedin.com/in/pratham-kumar-abb051175/">
             <i class="fab fa-linkedin-in"></i>
           </a>
-          <a href="https://github.com/PrathamKumar14">
+          <a href="https://github.com/PrathamKumar14" target="blank">
             <i class="fab fa-github"></i>
           </a>
           <a href="https://twitter.com/pratham85086605">


### PR DESCRIPTION
made changes so that your github profile opens in a new tab when clicked from your 'my-Resume' GitHub logo. Thus interviewer can quickly return to your resume page by switching to the previous tab after he had a look at your github profile :)